### PR TITLE
Debugging coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,5 @@ jdk:
   - oraclejdk8
 notifications:
   email: false
-before_install:
-  - pip install --user codecov
 after_success:
-  - codecov
+  - bash <(curl -s https://codecov.io/bash) -d


### PR DESCRIPTION
In reference to [this Codecov report](https://codecov.io/github/jkcclemens/khttp/src/main/kotlin/me/kyleclemens/khttp/structures/cookie/CookieJar.kt?ref=c9879cc9ce24cd4e215e49518617c1dcb5803835) which has coverage data for more lines then in the file [as seen here](https://codecov.io/api/github/jkcclemens/khttp/src/main/kotlin/me/kyleclemens/khttp/structures/cookie/CookieJar.kt?ref=c9879cc9ce24cd4e215e49518617c1dcb5803835)