### PR TITLE
Update GenericResponse.kt

### DIFF
--- a/src/main/kotlin/khttp/responses/GenericResponse.kt
+++ b/src/main/kotlin/khttp/responses/GenericResponse.kt
@@ -32,7 +32,7 @@ class GenericResponse internal constructor(override val request: Request) : Resp
     internal companion object {
 
         internal val HttpURLConnection.cookieJar: CookieJar
-            get() = CookieJar(*this.headerFields.filter { it.key == "Set-Cookie" }.flatMap { it.value }.filter {it.isNotEmpty()}map { Cookie(it) }.toTypedArray())
+            get() = CookieJar(*this.headerFields.filter { it.key == "Set-Cookie" }.flatMap { it.value }.filter {it.isNotEmpty()}.map { Cookie(it) }.toTypedArray())
 
         internal fun HttpURLConnection.forceMethod(method: String) {
             try {

--- a/src/main/kotlin/khttp/responses/GenericResponse.kt
+++ b/src/main/kotlin/khttp/responses/GenericResponse.kt
@@ -32,7 +32,7 @@ class GenericResponse internal constructor(override val request: Request) : Resp
     internal companion object {
 
         internal val HttpURLConnection.cookieJar: CookieJar
-            get() = CookieJar(*this.headerFields.filter { it.key == "Set-Cookie" }.flatMap { it.value }.map { Cookie(it) }.toTypedArray())
+            get() = CookieJar(*this.headerFields.filter { it.key == "Set-Cookie" }.flatMap { it.value }.filter {it.isNotEmpty()}map { Cookie(it) }.toTypedArray())
 
         internal fun HttpURLConnection.forceMethod(method: String) {
             try {


### PR DESCRIPTION
Line 35: Filter cookies map. Sometimes there is blank cookie string from Set-Cookie header, it will raise error while converting string to cookie in Cookie.kt