### PR TITLE
Added async functionality

### DIFF
--- a/src/main/kotlin/khttp/KHttp.kt
+++ b/src/main/kotlin/khttp/KHttp.kt
@@ -7,6 +7,8 @@
 
 package khttp
 
+import kotlin.concurrent.thread
+
 import khttp.requests.GenericRequest
 import khttp.responses.GenericResponse
 import khttp.responses.Response
@@ -60,5 +62,60 @@ fun request(method: String, url: String, headers: Map<String, String> = mapOf(),
         this._history.last().apply {
             this@run._history.remove(this)
         }
+    }
+}
+
+/**
+ * Provides a library interface for performing asynchronous requests
+ */
+class async {
+    companion object {
+
+        @JvmOverloads
+        fun delete(url: String, headers: Map<String, String> = mapOf(), params: Map<String, String> = mapOf(), data: Any? = null, json: Any? = null, auth: Authorization? = null, cookies: Map<String, String>? = null, timeout: Double = DEFAULT_TIMEOUT, allowRedirects: Boolean? = null, stream: Boolean = false, files: List<FileLike> = listOf(), onError: Throwable.() -> Unit = { throw this }, onResponse: Response.() -> Unit = {}): Unit {
+            request("DELETE", url, headers, params, data, json, auth, cookies, timeout, allowRedirects, stream, files, onError, onResponse)
+        }
+
+        @JvmOverloads
+        fun get(url: String, headers: Map<String, String> = mapOf(), params: Map<String, String> = mapOf(), data: Any? = null, json: Any? = null, auth: Authorization? = null, cookies: Map<String, String>? = null, timeout: Double = DEFAULT_TIMEOUT, allowRedirects: Boolean? = null, stream: Boolean = false, files: List<FileLike> = listOf(), onError: Throwable.() -> Unit = { throw this }, onResponse: Response.() -> Unit = {}): Unit {
+            request("GET", url, headers, params, data, json, auth, cookies, timeout, allowRedirects, stream, files, onError, onResponse)
+        }
+
+        @JvmOverloads
+        fun head(url: String, headers: Map<String, String> = mapOf(), params: Map<String, String> = mapOf(), data: Any? = null, json: Any? = null, auth: Authorization? = null, cookies: Map<String, String>? = null, timeout: Double = DEFAULT_TIMEOUT, allowRedirects: Boolean? = null, stream: Boolean = false, files: List<FileLike> = listOf(), onError: Throwable.() -> Unit = { throw this }, onResponse: Response.() -> Unit = {}): Unit {
+            request("HEAD", url, headers, params, data, json, auth, cookies, timeout, allowRedirects, stream, files, onError, onResponse)
+        }
+
+        @JvmOverloads
+        fun options(url: String, headers: Map<String, String> = mapOf(), params: Map<String, String> = mapOf(), data: Any? = null, json: Any? = null, auth: Authorization? = null, cookies: Map<String, String>? = null, timeout: Double = DEFAULT_TIMEOUT, allowRedirects: Boolean? = null, stream: Boolean = false, files: List<FileLike> = listOf(), onError: Throwable.() -> Unit = { throw this }, onResponse: Response.() -> Unit = {}): Unit {
+            request("OPTIONS", url, headers, params, data, json, auth, cookies, timeout, allowRedirects, stream, files, onError, onResponse)
+        }
+
+        @JvmOverloads
+        fun patch(url: String, headers: Map<String, String> = mapOf(), params: Map<String, String> = mapOf(), data: Any? = null, json: Any? = null, auth: Authorization? = null, cookies: Map<String, String>? = null, timeout: Double = DEFAULT_TIMEOUT, allowRedirects: Boolean? = null, stream: Boolean = false, files: List<FileLike> = listOf(), onError: Throwable.() -> Unit = { throw this }, onResponse: Response.() -> Unit = {}): Unit {
+            request("PATCH", url, headers, params, data, json, auth, cookies, timeout, allowRedirects, stream, files, onError, onResponse)
+        }
+
+        @JvmOverloads
+        fun post(url: String, headers: Map<String, String> = mapOf(), params: Map<String, String> = mapOf(), data: Any? = null, json: Any? = null, auth: Authorization? = null, cookies: Map<String, String>? = null, timeout: Double = DEFAULT_TIMEOUT, allowRedirects: Boolean? = null, stream: Boolean = false, files: List<FileLike> = listOf(), onError: Throwable.() -> Unit = { throw this }, onResponse: Response.() -> Unit = {}): Unit {
+            request("POST", url, headers, params, data, json, auth, cookies, timeout, allowRedirects, stream, files, onError, onResponse)
+        }
+
+        @JvmOverloads
+        fun put(url: String, headers: Map<String, String> = mapOf(), params: Map<String, String> = mapOf(), data: Any? = null, json: Any? = null, auth: Authorization? = null, cookies: Map<String, String>? = null, timeout: Double = DEFAULT_TIMEOUT, allowRedirects: Boolean? = null, stream: Boolean = false, files: List<FileLike> = listOf(), onError: Throwable.() -> Unit = { throw this }, onResponse: Response.() -> Unit = {}): Unit {
+            request("PUT", url, headers, params, data, json, auth, cookies, timeout, allowRedirects, stream, files, onError, onResponse)
+        }
+
+        @JvmOverloads
+        fun request(method: String, url: String, headers: Map<String, String> = mapOf(), params: Map<String, String> = mapOf(), data: Any? = null, json: Any? = null, auth: Authorization? = null, cookies: Map<String, String>? = null, timeout: Double = DEFAULT_TIMEOUT, allowRedirects: Boolean? = null, stream: Boolean = false, files: List<FileLike> = listOf(), onError: Throwable.() -> Unit = { throw this }, onResponse: Response.() -> Unit = {}): Unit {
+            thread {
+                try {
+                    onResponse(khttp.request(method, url, headers, params, data, json, auth, cookies, timeout, allowRedirects, stream, files))
+                } catch (e: Throwable) {
+                    onError(e)
+                }
+            }
+        }
+
     }
 }

--- a/src/test/kotlin/khttp/KHttpAsyncDeleteSpec.kt
+++ b/src/test/kotlin/khttp/KHttpAsyncDeleteSpec.kt
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package khttp
+
+import khttp.helpers.AsyncUtil
+import khttp.helpers.AsyncUtil.Companion.error
+import khttp.helpers.AsyncUtil.Companion.errorCallback
+import khttp.helpers.AsyncUtil.Companion.response
+import khttp.helpers.AsyncUtil.Companion.responseCallback
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import kotlin.test.assertEquals
+
+class KHttpAsyncDeleteSpec : Spek({
+    given("an async delete request") {
+        val url = "https://httpbin.org/delete"
+        beforeGroup {
+            AsyncUtil.execute { async.delete(url, onError = errorCallback, onResponse =  responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should have the same url") {
+                assertEquals(url, json.getString("url"))
+            }
+        }
+    }
+})

--- a/src/test/kotlin/khttp/KHttpAsyncGetSpec.kt
+++ b/src/test/kotlin/khttp/KHttpAsyncGetSpec.kt
@@ -1,0 +1,500 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package khttp
+
+import khttp.helpers.AsyncUtil
+import khttp.helpers.AsyncUtil.Companion.error
+import khttp.helpers.AsyncUtil.Companion.errorCallback
+import khttp.helpers.AsyncUtil.Companion.response
+import khttp.helpers.AsyncUtil.Companion.responseCallback
+import khttp.structures.authorization.BasicAuthorization
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.json.JSONObject
+import java.net.MalformedURLException
+import java.net.SocketTimeoutException
+import java.net.URLEncoder
+import java.util.zip.GZIPInputStream
+import java.util.zip.InflaterInputStream
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class KHttpAsyncGetSpec : Spek({
+    given("an async get request") {
+        val url = "http://httpbin.org/range/26"
+        beforeGroup {
+            AsyncUtil.execute { async.get(url, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the string") {
+            if (error != null) throw error!!
+            val string = response!!.text
+            it("should equal the alphabet in lowercase") {
+                assertEquals("abcdefghijklmnopqrstuvwxyz", string)
+            }
+        }
+        on("accessing the url") {
+            if (error != null) throw error!!
+            val resultantURL = response!!.url
+            it("should equal the starting url") {
+                assertEquals(url, resultantURL)
+            }
+        }
+        on("accessing the status code") {
+            if (error != null) throw error!!
+            val statusCode = response!!.statusCode
+            it("should be 200") {
+                assertEquals(200, statusCode)
+            }
+        }
+        on("converting it to a string") {
+            if (error != null) throw error!!
+            val string = response!!.toString()
+            it("should be correct") {
+                assertEquals("<Response [200]>", string)
+            }
+        }
+    }
+    given("an async json object get request with parameters") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/get", params = mapOf("a" to "b", "c" to "d"), onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should contain the parameters") {
+                val args = json.getJSONObject("args")
+                assertEquals("b", args.getString("a"))
+                assertEquals("d", args.getString("c"))
+            }
+        }
+    }
+    given("an async json object get request with a map of parameters") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/get", params = mapOf("a" to "b", "c" to "d"), onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should contain the parameters") {
+                val args = json.getJSONObject("args")
+                assertEquals("b", args.getString("a"))
+                assertEquals("d", args.getString("c"))
+            }
+        }
+    }
+    given("an async get request with basic auth") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/basic-auth/khttp/isawesome", auth = BasicAuthorization("khttp", "isawesome"), onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should be authenticated") {
+                assertTrue(json.getBoolean("authenticated"))
+            }
+            it("should have the correct user") {
+                assertEquals("khttp", json.getString("user"))
+            }
+        }
+    }
+    given("an async get request with cookies") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/cookies", cookies = mapOf("test" to "success"), onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should have the same cookies") {
+                val cookies = json.getJSONObject("cookies")
+                assertEquals("success", cookies.getString("test"))
+            }
+        }
+    }
+    given("an async get request that redirects and allowing redirects") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/redirect-to?url=${URLEncoder.encode("http://httpbin.org/get", "utf-8")}", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should have the redirected url") {
+                assertEquals("http://httpbin.org/get", json.getString("url"))
+            }
+        }
+    }
+    given("an async get request that redirects and disallowing redirects") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/redirect-to?url=${URLEncoder.encode("http://httpbin.org/get", "utf-8")}", allowRedirects = false, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the status code") {
+            if (error != null) throw error!!
+            val code = response!!.statusCode
+            it("should be 302") {
+                assertEquals(302, code)
+            }
+        }
+    }
+    given("an async get request that redirects five times") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/redirect/5", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should have the get url") {
+                assertEquals("http://httpbin.org/get", json.getString("url"))
+            }
+        }
+    }
+    given("an async get request that takes ten seconds to complete") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/delay/10", timeout = 1.0, onError = { AsyncUtil.set(err = this) }) }
+        }
+        on("request") {
+            it("should throw a timeout exception") {
+                assertFailsWith(SocketTimeoutException::class) {
+                    throw error!!
+                }
+            }
+        }
+    }
+    given("an async get request that sets cookies without redirects") {
+        val cookieName = "test"
+        val cookieValue = "quite"
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/cookies/set?$cookieName=$cookieValue", allowRedirects = false, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("inspecting the cookies") {
+            if (error != null) throw error!!
+            val cookies = response!!.cookies
+            it("should set a cookie") {
+                assertEquals(1, cookies.size)
+            }
+            val cookie = cookies.getCookie(cookieName)
+            val text = cookies[cookieName]
+            it("should have the specified cookie name") {
+                assertNotNull(cookie)
+            }
+            it("should have the specified text") {
+                assertNotNull(text)
+            }
+            it("should have the same value") {
+                assertEquals(cookieValue, cookie!!.value)
+            }
+            it("should have the same text value") {
+                // Attributes ignored
+                assertEquals(cookieValue, text!!.toString().split(";")[0])
+            }
+        }
+    }
+    given("an async get request that sets cookies with redirects") {
+        val cookieName = "test"
+        val cookieValue = "quite"
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/cookies/set?$cookieName=$cookieValue", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("inspecting the cookies") {
+            if (error != null) throw error!!
+            val cookies = response!!.cookies
+            it("should set a cookie") {
+                assertEquals(1, cookies.size)
+            }
+            val cookie = cookies.getCookie(cookieName)
+            val text = cookies[cookieName]
+            it("should have the specified cookie name") {
+                assertNotNull(cookie)
+            }
+            it("should have the specified text") {
+                assertNotNull(text)
+            }
+            it("should have the same value") {
+                assertEquals(cookieValue, cookie!!.value)
+            }
+            it("should have the same text value") {
+                // Attributes ignored
+                assertEquals(cookieValue, text!!.toString().split(";")[0])
+            }
+        }
+    }
+    given("an async get request that sets multiple cookies with redirects") {
+        val cookieNameOne = "test"
+        val cookieValueOne = "quite"
+        val cookieNameTwo = "derp"
+        val cookieValueTwo = "herp"
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/cookies/set?$cookieNameOne=$cookieValueOne&$cookieNameTwo=$cookieValueTwo", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("inspecting the cookies") {
+            if (error != null) throw error!!
+            val cookies = response!!.cookies
+            it("should set two cookies") {
+                assertEquals(2, cookies.size)
+            }
+            val cookie = cookies.getCookie(cookieNameOne)
+            val text = cookies[cookieNameOne]
+            it("should have the specified cookie name") {
+                assertNotNull(cookie)
+            }
+            it("should have the specified text") {
+                assertNotNull(text)
+            }
+            it("should have the same value") {
+                assertEquals(cookieValueOne, cookie!!.value)
+            }
+            it("should have the same text value") {
+                // Attributes ignored
+                assertEquals(cookieValueOne, text!!.toString().split(";")[0])
+            }
+            val cookieTwo = cookies.getCookie(cookieNameTwo)
+            val textTwo = cookies[cookieNameTwo]
+            it("should have the specified cookie name") {
+                assertNotNull(cookieTwo)
+            }
+            it("should have the specified text") {
+                assertNotNull(textTwo)
+            }
+            it("should have the same value") {
+                assertEquals(cookieValueTwo, cookieTwo!!.value)
+            }
+            it("should have the same text value") {
+                // Attributes ignored
+                assertEquals(cookieValueTwo, textTwo!!.toString().split(";")[0])
+            }
+        }
+    }
+    given("an async gzip get request") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("https://httpbin.org/gzip", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the stream") {
+            if (error != null) throw error!!
+            val stream = response!!.raw
+            it("should be a GZIPInputStream") {
+                assertTrue(stream is GZIPInputStream)
+            }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should be gzipped") {
+                assertTrue(json.getBoolean("gzipped"))
+            }
+        }
+    }
+    given("an async deflate get request") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("https://httpbin.org/deflate", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the stream") {
+            if (error != null) throw error!!
+            val stream = response!!.raw
+            it("should be a InflaterInputStream") {
+                assertTrue(stream is InflaterInputStream)
+            }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should be deflated") {
+                assertTrue(json.getBoolean("deflated"))
+            }
+        }
+    }
+    given("an async get request that returns 418") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("https://httpbin.org/status/418", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the status code") {
+            if (error != null) throw error!!
+            val status = response!!.statusCode
+            it("should be 418") {
+                assertEquals(418, status)
+            }
+        }
+        on("accessing the text") {
+            if (error != null) throw error!!
+            val text = response!!.text
+            it("should contain \"teapot\"") {
+                assertTrue(text.contains("teapot"))
+            }
+        }
+    }
+    given("an async get request for a UTF-8 document") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("https://httpbin.org/encoding/utf8", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("checking the encoding") {
+            if (error != null) throw error!!
+            val encoding = response!!.encoding
+            it("should be UTF-8") {
+                assertEquals(Charsets.UTF_8, encoding)
+            }
+        }
+        on("reading the text") {
+            if (error != null) throw error!!
+            val text = response!!.text
+            it("should contain ∮") {
+                assertTrue(text.contains("∮"))
+            }
+        }
+        on("changing the encoding") {
+            if (error != null) throw error!!
+            response!!.encoding = Charsets.ISO_8859_1
+            val encoding = response!!.encoding
+            it("should be ISO-8859-1") {
+                assertEquals(Charsets.ISO_8859_1, encoding)
+            }
+        }
+        on("reading the text") {
+            if (error != null) throw error!!
+            val text = response!!.text
+            it("should not contain ∮") {
+                assertFalse(text.contains("∮"))
+            }
+        }
+    }
+    given("an async unsupported khttp schema") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("ftp://google.com", onError = { AsyncUtil.set(err = this) }) }
+        }
+        on("construction") {
+            it("should throw an IllegalArgumentException") {
+                assertFailsWith(IllegalArgumentException::class) {
+                    throw error!!
+                }
+            }
+        }
+    }
+    given("an async unsupported Java schema") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("gopher://google.com", onError = { AsyncUtil.set(err = this) }) }
+        }
+        on("construction") {
+            it("should throw a MalformedURLException") {
+                assertFailsWith(MalformedURLException::class) {
+                    throw error!!
+                }
+            }
+        }
+    }
+    given("an async request with a user agent set") {
+        val userAgent = "khttp/test"
+        beforeGroup {
+            AsyncUtil.execute { async.get("https://httpbin.org/user-agent", headers = mapOf("User-Agent" to userAgent), onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            val responseUserAgent = json.getString("user-agent")
+            it("should have the same user agent") {
+                assertEquals(userAgent, responseUserAgent)
+            }
+        }
+    }
+    given("an async request with a port") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("https://httpbin.org:443/get", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should not be null") {
+                assertNotNull(json)
+            }
+        }
+    }
+    given("an async get request for a JSON array") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://jsonplaceholder.typicode.com/users", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonArray
+            it("should have ten items") {
+                assertEquals(10, json.length())
+            }
+        }
+    }
+    given("an async non-streaming get request") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("https://httpbin.org/get", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("checking the bytes available to be read") {
+            if (error != null) throw error!!
+            val available = response!!.raw.available()
+            it("should be 0") {
+                assertEquals(0, available)
+            }
+        }
+    }
+    given("an async streaming get request") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("https://httpbin.org/get", stream = true, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("checking the bytes available to be read") {
+            if (error != null) throw error!!
+            val available = response!!.raw.available()
+            it("should be greater than 0") {
+                assertTrue(available > 0)
+            }
+        }
+    }
+    given("an async streaming get request with a streaming line response") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/stream/4", stream = true, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("iterating over the lines") {
+            if (error != null) throw error!!
+            val iterator = response!!.lineIterator()
+            var counter = 0
+            for (line in iterator) {
+                val json = JSONObject(line.toString(response!!.encoding))
+                assertEquals(counter++, json.getInt("id"))
+            }
+            it("should have iterated 4 times") {
+                assertEquals(4, counter)
+            }
+        }
+    }
+    given("an async streaming get request with a streaming byte response") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/stream-bytes/4?seed=1", stream = true, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("iterating over the bytes") {
+            if (error != null) throw error!!
+            val iterator = response!!.contentIterator(chunkSize = 1)
+            var counter = 0
+            val expected = byteArrayOf(0x22, 0xD8.toByte(), 0xC3.toByte(), 0x41)
+            for (byte in iterator) {
+                assertEquals(1, byte.size)
+                assertEquals(expected[counter++], byte[0])
+            }
+            it("should have iterated 4 times") {
+                assertEquals(4, counter)
+            }
+        }
+    }
+    given("an async streaming get request without even lines") {
+        val url = "https://httpbin.org/bytes/1690?seed=1"
+        beforeGroup {
+            AsyncUtil.execute { async.get(url, stream = true, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("iterating the lines") {
+            if (error != null) throw error!!
+            val iterator = response!!.lineIterator()
+            val bytes = iterator.asSequence().toList().flatMap { it.toList() }
+            val contentWithoutBytes = get(url).content.toList().filter { it != '\r'.toByte() && it != '\n'.toByte() }
+            it("should be the same as the content without line breaks") {
+                assertEquals(contentWithoutBytes, bytes)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/khttp/KHttpAsyncHeadSpec.kt
+++ b/src/test/kotlin/khttp/KHttpAsyncHeadSpec.kt
@@ -1,0 +1,56 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package khttp
+
+import khttp.helpers.AsyncUtil
+import khttp.helpers.AsyncUtil.Companion.error
+import khttp.helpers.AsyncUtil.Companion.errorCallback
+import khttp.helpers.AsyncUtil.Companion.response
+import khttp.helpers.AsyncUtil.Companion.responseCallback
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import kotlin.test.assertEquals
+
+class KHttpAsyncHeadSpec : Spek({
+    given("an async head request") {
+        beforeGroup {
+            AsyncUtil.execute { async.head("https://httpbin.org/get", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the status code") {
+            if (error != null) throw error!!
+            val status = response!!.statusCode
+            it("should be 200") {
+                assertEquals(200, status)
+            }
+        }
+    }
+    given("an async head request to a redirecting URL") {
+        beforeGroup {
+            AsyncUtil.execute { async.head("https://httpbin.org/redirect/2", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the status code") {
+            if (error != null) throw error!!
+            val status = response!!.statusCode
+            it("should be 302") {
+                assertEquals(302, status)
+            }
+        }
+    }
+    given("an async head request to a redirecting URL, specifically allowing redirects") {
+        beforeGroup {
+            AsyncUtil.execute { async.head("https://httpbin.org/redirect/2", allowRedirects = true, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the status code") {
+            if (error != null) throw error!!
+            val status = response!!.statusCode
+            it("should be 200") {
+                assertEquals(200, status)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/khttp/KHttpAsyncOptionsSpec.kt
+++ b/src/test/kotlin/khttp/KHttpAsyncOptionsSpec.kt
@@ -1,0 +1,32 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package khttp
+
+import khttp.helpers.AsyncUtil
+import khttp.helpers.AsyncUtil.Companion.error
+import khttp.helpers.AsyncUtil.Companion.errorCallback
+import khttp.helpers.AsyncUtil.Companion.response
+import khttp.helpers.AsyncUtil.Companion.responseCallback
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import kotlin.test.assertEquals
+
+class KHttpAsyncOptionsSpec : Spek({
+    given("an async options request") {
+        beforeGroup {
+            AsyncUtil.execute { async.options("https://httpbin.org/get", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the status code") {
+            if (error != null) throw error!!
+            val status = response!!.statusCode
+            it("should be 200") {
+                assertEquals(200, status)
+            }
+        }
+    }
+})

--- a/src/test/kotlin/khttp/KHttpAsyncPatchSpec.kt
+++ b/src/test/kotlin/khttp/KHttpAsyncPatchSpec.kt
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package khttp
+
+import khttp.helpers.AsyncUtil
+import khttp.helpers.AsyncUtil.Companion.error
+import khttp.helpers.AsyncUtil.Companion.errorCallback
+import khttp.helpers.AsyncUtil.Companion.response
+import khttp.helpers.AsyncUtil.Companion.responseCallback
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import kotlin.test.assertEquals
+
+class KHttpAsyncPatchSpec : Spek({
+    given("an async patch request") {
+        val url = "https://httpbin.org/patch"
+        beforeGroup {
+            AsyncUtil.execute { async.patch(url, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should have the same url") {
+                assertEquals(url, json.getString("url"))
+            }
+        }
+    }
+})

--- a/src/test/kotlin/khttp/KHttpAsyncPostSpec.kt
+++ b/src/test/kotlin/khttp/KHttpAsyncPostSpec.kt
@@ -1,0 +1,274 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package khttp
+
+import khttp.extensions.fileLike
+import khttp.helpers.AsyncUtil
+import khttp.helpers.AsyncUtil.Companion.error
+import khttp.helpers.AsyncUtil.Companion.errorCallback
+import khttp.helpers.AsyncUtil.Companion.response
+import khttp.helpers.AsyncUtil.Companion.responseCallback
+import khttp.helpers.StringIterable
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.util.Base64
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class KHttpAsyncPostSpec : Spek({
+    given("an async post request with raw data") {
+        beforeGroup {
+            AsyncUtil.execute { async.post("http://httpbin.org/post", data = "Hello, world!", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should contain the data") {
+                assertEquals("Hello, world!", json.getString("data"))
+            }
+        }
+    }
+    given("an async post form request") {
+        beforeGroup {
+            AsyncUtil.execute { async.post("http://httpbin.org/post", data = mapOf("a" to "b", "c" to "d"), onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should contain the form data") {
+                val form = json.getJSONObject("form")
+                assertEquals("b", form.getString("a"))
+                assertEquals("d", form.getString("c"))
+            }
+        }
+    }
+    given("an async request with json as a Map") {
+        val jsonMap = mapOf("books" to listOf(mapOf("title" to "Pride and Prejudice", "author" to "Jane Austen")))
+        beforeGroup {
+            AsyncUtil.execute { async.post("http://httpbin.org/post", json = jsonMap, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            val returnedJSON = json.getJSONObject("json")
+            val returnedBooks = returnedJSON.getJSONArray("books")
+            it("should be the same length") {
+                assertEquals(jsonMap.size, returnedJSON.length())
+            }
+            it("should have the same book length") {
+                assertEquals(jsonMap.get("books")!!.size, returnedBooks.length())
+            }
+            val firstBook = jsonMap.get("books")!!.get(0)
+            val firstReturnedBook = returnedBooks.getJSONObject(0)
+            it("should have the same book title") {
+                assertEquals(firstBook["title"], firstReturnedBook.getString("title"))
+            }
+            it("should have the same book author") {
+                assertEquals(firstBook["author"], firstReturnedBook.getString("author"))
+            }
+        }
+    }
+    given("an async request with json as an Iterable") {
+        val jsonArray = StringIterable("a word")
+        beforeGroup {
+            AsyncUtil.execute { async.post("http://httpbin.org/post", json = jsonArray, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            val returnedJSON = json.getJSONArray("json")
+            it("should be equal") {
+                assertEquals(jsonArray.string, String(returnedJSON.mapIndexed { i, any -> returnedJSON.getString(i)[0] }.toCharArray()))
+            }
+        }
+    }
+    given("an async request with json as a List") {
+        val jsonList = listOf("A thing", "another thing")
+        beforeGroup {
+            AsyncUtil.execute { async.post("https://httpbin.org/post", json = jsonList, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            val returnedJSON = json.getJSONArray("json")
+            it("should have an equal first element") {
+                assertEquals(jsonList[0], returnedJSON.getString(0))
+            }
+            it("should have an equal second element") {
+                assertEquals(jsonList[1], returnedJSON.getString(1))
+            }
+        }
+    }
+    given("an async request with json as an Array") {
+        val jsonArray = arrayOf("A thing", "another thing")
+        beforeGroup {
+            AsyncUtil.execute { async.post("https://httpbin.org/post", json = jsonArray, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            val returnedJSON = json.getJSONArray("json")
+            it("should have an equal first element") {
+                assertEquals(jsonArray[0], returnedJSON.getString(0))
+            }
+            it("should have an equal second element") {
+                assertEquals(jsonArray[1], returnedJSON.getString(1))
+            }
+        }
+    }
+    given("an async request with json as a JSONObject") {
+        val jsonObject = JSONObject("""{"valid": true}""")
+        beforeGroup {
+            AsyncUtil.execute { async.post("https://httpbin.org/post", json = jsonObject, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            val returnedJSON = json.getJSONObject("json")
+            it("should have a true value for the key \"valid\"") {
+                assertTrue(returnedJSON.getBoolean("valid"))
+            }
+        }
+    }
+    given("an async request with json as a JSONArray") {
+        val jsonObject = JSONArray("[true]")
+        beforeGroup {
+            AsyncUtil.execute { async.post("https://httpbin.org/post", json = jsonObject, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            val returnedJSON = json.getJSONArray("json")
+            it("should have a true value for the first key") {
+                assertTrue(returnedJSON.getBoolean(0))
+            }
+        }
+    }
+    given("an async request with invalid json") {
+        beforeGroup {
+            AsyncUtil.execute { async.post("https://httpbin.org/post", json = object {}, onError = { AsyncUtil.set(err = this) }) }
+        }
+        on("construction") {
+            it("should throw an IllegalArgumentException") {
+                assertFailsWith(IllegalArgumentException::class) {
+                    throw error!!
+                }
+            }
+        }
+    }
+    given("an async file upload without form parameters") {
+        val file = "hello".fileLike("derp")
+        beforeGroup {
+            AsyncUtil.execute { async.post("https://httpbin.org/post", files = listOf(file), onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            val files = json.getJSONObject("files")
+            it("should have one file") {
+                assertEquals(1, files.length())
+            }
+            it("should have the same name") {
+                assertNotNull(files.optString(file.name, null))
+            }
+            it("should have the same contents") {
+                assertEquals(file.contents.toString(Charsets.UTF_8), files.optString(file.name))
+            }
+        }
+    }
+    given("an async file upload with form parameters") {
+        val file = "hello".fileLike("derp")
+        val params = mapOf("top" to "kek")
+        beforeGroup {
+            AsyncUtil.execute { async.post("https://httpbin.org/post", files = listOf(file), data = params, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            val files = json.getJSONObject("files")
+            val form = json.getJSONObject("form")
+            it("should have one file") {
+                assertEquals(1, files.length())
+            }
+            it("should have the same name") {
+                assertNotNull(files.optString(file.name, null))
+            }
+            it("should have the same contents") {
+                assertEquals(file.contents.toString(Charsets.UTF_8), files.optString(file.name))
+            }
+            it("should have one parameter") {
+                assertEquals(1, form.length())
+            }
+            it("should have the same name") {
+                assertNotNull(form.optString("top", null))
+            }
+            it("should have the same contents") {
+                assertEquals("kek", form.optString("top"))
+            }
+        }
+    }
+    given("an async streaming file upload") {
+        // Get our file to stream (a beautiful rare pepe)
+        val file = File("src/test/resources/rarest_of_pepes.png")
+        beforeGroup {
+            AsyncUtil.execute { async.post("https://httpbin.org/post", data = file, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the data") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            val data = json.getString("data")
+            it("should start with a base64 header") {
+                assertTrue(data.startsWith("data:application/octet-stream;base64,"))
+            }
+            val base64 = data.split("data:application/octet-stream;base64,")[1]
+            val rawData = Base64.getDecoder().decode(base64)
+            it("should be the same decoded content") {
+                assertEquals(file.readBytes().asList(), rawData.asList())
+            }
+        }
+    }
+    given("an async streaming InputStream upload") {
+        // Get our file to stream (a beautiful rare pepe)
+        val file = File("src/test/resources/rarest_of_pepes.png")
+        val inputStream = file.inputStream()
+        beforeGroup {
+            AsyncUtil.execute { async.post("https://httpbin.org/post", data = inputStream, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the data") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            val data = json.getString("data")
+            it("should start with a base64 header") {
+                assertTrue(data.startsWith("data:application/octet-stream;base64,"))
+            }
+            val base64 = data.split("data:application/octet-stream;base64,")[1]
+            val rawData = Base64.getDecoder().decode(base64)
+            it("should be the same decoded content") {
+                assertEquals(file.readBytes().asList(), rawData.asList())
+            }
+        }
+    }
+    given("an async JSON request") {
+        val expected = """{"test":true}"""
+        beforeGroup {
+            AsyncUtil.execute { async.post("https://httpbin.org/post", json = mapOf("test" to true), onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the request body") {
+            if (error != null) throw error!!
+            val body = response!!.request.body
+            it("should be the expected valid json") {
+                assertEquals(expected, body.toString(Charsets.UTF_8))
+            }
+        }
+    }
+})

--- a/src/test/kotlin/khttp/KHttpAsyncPutSpec.kt
+++ b/src/test/kotlin/khttp/KHttpAsyncPutSpec.kt
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package khttp
+
+import khttp.helpers.AsyncUtil
+import khttp.helpers.AsyncUtil.Companion.error
+import khttp.helpers.AsyncUtil.Companion.errorCallback
+import khttp.helpers.AsyncUtil.Companion.response
+import khttp.helpers.AsyncUtil.Companion.responseCallback
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import kotlin.test.assertEquals
+
+class KHttpAsyncPutSpec : Spek({
+    given("a put request") {
+        val url = "https://httpbin.org/put"
+        beforeGroup {
+            AsyncUtil.execute { async.put(url, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should have the same url") {
+                assertEquals(url, json.getString("url"))
+            }
+        }
+    }
+})

--- a/src/test/kotlin/khttp/helpers/AsyncUtil.kt
+++ b/src/test/kotlin/khttp/helpers/AsyncUtil.kt
@@ -1,0 +1,64 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package khttp.helpers
+
+import khttp.responses.Response
+
+/**
+ * Utility to aid in executing asynchronous tests in Spek
+ */
+class AsyncUtil {
+    companion object {
+        /**
+         * The current response object
+         */
+        var response: Response? = null
+
+        /**
+         * The current error object
+         */
+        var error: Throwable? = null
+
+        /**
+         * Mutex for the request
+         */
+        val requestMutex = java.lang.Object()
+
+        /**
+         * Default error callback
+         */
+        val errorCallback: Throwable.() -> Unit = { set(err = this) }
+
+        /**
+         * Default response callback
+         */
+        val responseCallback: Response.() -> Unit = { set(this) }
+
+        /**
+         * Executes a khttp asynchronous request synchronously
+         * @param request a block of code that performs the khttp async request
+         */
+        fun execute(request: () -> Unit): Unit {
+            response = null
+            error = null
+            request()
+            synchronized(requestMutex) { while (response == null && error == null) requestMutex.wait() }
+        }
+
+        /**
+         * Sets the response and/or error values of the companion object
+         * @param resp the value of the response
+         * @param err the value of the error
+         */
+        fun set(resp: Response? = null, err: Throwable? = null): Unit {
+            synchronized(requestMutex) {
+                response = resp
+                error = err
+                requestMutex.notifyAll()
+            }
+        }
+    }
+}


### PR DESCRIPTION
This addresses #14 by providing a library implementation of asynchrony using threads and includes a lambda receiver callback mechanism (no promise based approach).

Usage is as follows:
```kotlin
khttp.async.get("https://www.google.com/") {
    println("Status Code: $statusCode")
    println("Response Text: $text")
}
// OR ...
khttp.async.get("https://www.google.com/", onError = {
   println("Error message: $message")
}, onResponse = {
    println("Status Code: $statusCode")
    println("Response Text: $text")
})
```

Each original library test is extended to apply to the corresponding `async` version.

Hopefully this approach adheres to the core design principles of the library and the provided implementation satisfies all necessary constraints.