### PR TITLE
Separate name in FileLike to fieldName and fileName

### DIFF
--- a/src/main/kotlin/khttp/requests/GenericRequest.kt
+++ b/src/main/kotlin/khttp/requests/GenericRequest.kt
@@ -111,7 +111,7 @@ class GenericRequest internal constructor(
                     // Add the files
                     files.forEach {
                         writer.writeAndFlush("--$boundary\r\n")
-                        writer.writeAndFlush("Content-Disposition: form-data; name=\"${it.name}\"; filename=\"${it.name}\"\r\n\r\n")
+                        writer.writeAndFlush("Content-Disposition: form-data; name=\"${it.fieldName}\"; filename=\"${it.fileName}\"\r\n\r\n")
                         bytes.write(it.contents)
                         writer.writeAndFlush("\r\n")
                     }

--- a/src/main/kotlin/khttp/structures/files/FileLike.kt
+++ b/src/main/kotlin/khttp/structures/files/FileLike.kt
@@ -8,7 +8,7 @@ package khttp.structures.files
 import java.io.File
 import java.nio.file.Path
 
-class FileLike(val name: String, val contents: ByteArray) {
+class FileLike(val fieldName: String, val fileName: String, val contents: ByteArray) {
 
     constructor(name: String, contents: String) : this(name, contents.toByteArray())
 
@@ -20,4 +20,5 @@ class FileLike(val name: String, val contents: ByteArray) {
 
     constructor(path: Path) : this(path.toFile())
 
+    constructor(name: String, contents: ByteArray) : this(name, name, contents)
 }

--- a/src/test/kotlin/khttp/KHttpAsyncPostSpec.kt
+++ b/src/test/kotlin/khttp/KHttpAsyncPostSpec.kt
@@ -179,10 +179,10 @@ class KHttpAsyncPostSpec : Spek({
                 assertEquals(1, files.length())
             }
             it("should have the same name") {
-                assertNotNull(files.optString(file.name, null))
+                assertNotNull(files.optString(file.fieldName, null))
             }
             it("should have the same contents") {
-                assertEquals(file.contents.toString(Charsets.UTF_8), files.optString(file.name))
+                assertEquals(file.contents.toString(Charsets.UTF_8), files.optString(file.fieldName))
             }
         }
     }
@@ -201,10 +201,10 @@ class KHttpAsyncPostSpec : Spek({
                 assertEquals(1, files.length())
             }
             it("should have the same name") {
-                assertNotNull(files.optString(file.name, null))
+                assertNotNull(files.optString(file.fieldName, null))
             }
             it("should have the same contents") {
-                assertEquals(file.contents.toString(Charsets.UTF_8), files.optString(file.name))
+                assertEquals(file.contents.toString(Charsets.UTF_8), files.optString(file.fieldName))
             }
             it("should have one parameter") {
                 assertEquals(1, form.length())

--- a/src/test/kotlin/khttp/KHttpPostSpec.kt
+++ b/src/test/kotlin/khttp/KHttpPostSpec.kt
@@ -153,10 +153,10 @@ class KHttpPostSpec : Spek({
                 assertEquals(1, files.length())
             }
             it("should have the same name") {
-                assertNotNull(files.optString(file.name, null))
+                assertNotNull(files.optString(file.fieldName, null))
             }
             it("should have the same contents") {
-                assertEquals(file.contents.toString(Charsets.UTF_8), files.optString(file.name))
+                assertEquals(file.contents.toString(Charsets.UTF_8), files.optString(file.fieldName))
             }
         }
     }
@@ -172,10 +172,10 @@ class KHttpPostSpec : Spek({
                 assertEquals(1, files.length())
             }
             it("should have the same name") {
-                assertNotNull(files.optString(file.name, null))
+                assertNotNull(files.optString(file.fieldName, null))
             }
             it("should have the same contents") {
-                assertEquals(file.contents.toString(Charsets.UTF_8), files.optString(file.name))
+                assertEquals(file.contents.toString(Charsets.UTF_8), files.optString(file.fieldName))
             }
             it("should have one parameter") {
                 assertEquals(1, form.length())

--- a/src/test/kotlin/khttp/structures/files/FileLikeSpec.kt
+++ b/src/test/kotlin/khttp/structures/files/FileLikeSpec.kt
@@ -20,7 +20,7 @@ class FileLikeSpec : Spek({
         on("creating a FileLike without a custom name") {
             val fileLike = file.fileLike()
             it("should have the same name") {
-                assertEquals(NAME, fileLike.name)
+                assertEquals(NAME, fileLike.fieldName)
             }
             it("should have the same contents") {
                 assertEquals(file.readBytes().asList(), fileLike.contents.asList())
@@ -30,7 +30,7 @@ class FileLikeSpec : Spek({
             val name = "not_rare_pepe.png"
             val fileLike = file.fileLike(name = name)
             it("should have the custom name") {
-                assertEquals(name, fileLike.name)
+                assertEquals(name, fileLike.fieldName)
             }
             it("should have the same contents") {
                 assertEquals(file.readBytes().asList(), fileLike.contents.asList())
@@ -42,7 +42,7 @@ class FileLikeSpec : Spek({
         on("creating a FileLike without a custom name") {
             val fileLike = path.fileLike()
             it("should have the same name") {
-                assertEquals(NAME, fileLike.name)
+                assertEquals(NAME, fileLike.fieldName)
             }
             it("should have the same contents") {
                 assertEquals(path.toFile().readBytes().asList(), fileLike.contents.asList())
@@ -52,7 +52,7 @@ class FileLikeSpec : Spek({
             val name = "not_rare_pepe.png"
             val fileLike = path.fileLike(name = name)
             it("should have the custom name") {
-                assertEquals(name, fileLike.name)
+                assertEquals(name, fileLike.fieldName)
             }
             it("should have the same contents") {
                 assertEquals(path.toFile().readBytes().asList(), fileLike.contents.asList())
@@ -65,7 +65,7 @@ class FileLikeSpec : Spek({
             val name = "not_rare_pepe.png"
             val fileLike = string.fileLike(name = name)
             it("should have the custom name") {
-                assertEquals(name, fileLike.name)
+                assertEquals(name, fileLike.fieldName)
             }
             it("should have the same contents") {
                 assertEquals(string.toByteArray().asList(), fileLike.contents.asList())


### PR DESCRIPTION
Sometimes it is different (for example - crowdin.com don't work without this patch)