### PR TITLE
Support HTTP 307 and HTTP 308 redirects

### DIFF
--- a/src/main/kotlin/khttp/responses/GenericResponse.kt
+++ b/src/main/kotlin/khttp/responses/GenericResponse.kt
@@ -124,7 +124,7 @@ class GenericResponse internal constructor(override val request: Request) : Resp
             this.receiver()
             this.connect()
         }
-        if (first.request.allowRedirects && connection.responseCode in 301..303) {
+        if (first.request.allowRedirects && connection.responseCode in arrayOf(301, 302, 303, 307, 308)) {
             val cookies = connection.cookieJar
             val req = with(first.request) {
                 GenericResponse(

--- a/src/test/kotlin/khttp/KHttpAsyncGetSpec.kt
+++ b/src/test/kotlin/khttp/KHttpAsyncGetSpec.kt
@@ -130,6 +130,30 @@ class KHttpAsyncGetSpec : Spek({
             }
         }
     }
+    given("an async get request that redirects with HTTP 307 and allowing redirects") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/redirect-to?status_code=307&url=${URLEncoder.encode("http://httpbin.org/get", "utf-8")}", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should have the redirected url") {
+                assertEquals("http://httpbin.org/get", json.getString("url"))
+            }
+        }
+    }
+    given("an async get request that redirects with HTTP 308 and allowing redirects") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/redirect-to?status_code=308&url=${URLEncoder.encode("http://httpbin.org/get", "utf-8")}", onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the json") {
+            if (error != null) throw error!!
+            val json = response!!.jsonObject
+            it("should have the redirected url") {
+                assertEquals("http://httpbin.org/get", json.getString("url"))
+            }
+        }
+    }
     given("an async get request that redirects and disallowing redirects") {
         beforeGroup {
             AsyncUtil.execute { async.get("http://httpbin.org/redirect-to?url=${URLEncoder.encode("http://httpbin.org/get", "utf-8")}", allowRedirects = false, onError = errorCallback, onResponse = responseCallback) }
@@ -139,6 +163,30 @@ class KHttpAsyncGetSpec : Spek({
             val code = response!!.statusCode
             it("should be 302") {
                 assertEquals(302, code)
+            }
+        }
+    }
+    given("an async get request that redirects with HTTP 307 and disallowing redirects") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/redirect-to?status_code=307&url=${URLEncoder.encode("http://httpbin.org/get", "utf-8")}", allowRedirects = false, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the status code") {
+            if (error != null) throw error!!
+            val code = response!!.statusCode
+            it("should be 307") {
+                assertEquals(307, code)
+            }
+        }
+    }
+    given("an async get request that redirects with HTTP 308 and disallowing redirects") {
+        beforeGroup {
+            AsyncUtil.execute { async.get("http://httpbin.org/redirect-to?status_code=308&url=${URLEncoder.encode("http://httpbin.org/get", "utf-8")}", allowRedirects = false, onError = errorCallback, onResponse = responseCallback) }
+        }
+        on("accessing the status code") {
+            if (error != null) throw error!!
+            val code = response!!.statusCode
+            it("should be 308") {
+                assertEquals(308, code)
             }
         }
     }

--- a/src/test/kotlin/khttp/KHttpGetSpec.kt
+++ b/src/test/kotlin/khttp/KHttpGetSpec.kt
@@ -103,12 +103,48 @@ class KHttpGetSpec : Spek({
             }
         }
     }
+    given("a get request that redirects with HTTP 307 and allowing redirects") {
+        val response = get("http://httpbin.org/redirect-to?status_code=307&url=http://httpbin.org/get")
+        on("accessing the json") {
+            val json = response.jsonObject
+            it("should have the redirected url") {
+                assertEquals("http://httpbin.org/get", json.getString("url"))
+            }
+        }
+    }
+    given("a get request that redirects with HTTP 308 and allowing redirects") {
+        val response = get("http://httpbin.org/redirect-to?status_code=308&url=http://httpbin.org/get")
+        on("accessing the json") {
+            val json = response.jsonObject
+            it("should have the redirected url") {
+                assertEquals("http://httpbin.org/get", json.getString("url"))
+            }
+        }
+    }
     given("a get request that redirects and disallowing redirects") {
         val response = get("http://httpbin.org/redirect-to?url=http://httpbin.org/get", allowRedirects = false)
         on("accessing the status code") {
             val code = response.statusCode
             it("should be 302") {
                 assertEquals(302, code)
+            }
+        }
+    }
+    given("a get request that redirects with HTTP 307 and disallowing redirects") {
+        val response = get("http://httpbin.org/redirect-to?status_code=307&url=http://httpbin.org/get", allowRedirects = false)
+        on("accessing the status code") {
+            val code = response.statusCode
+            it("should be 307") {
+                assertEquals(307, code)
+            }
+        }
+    }
+    given("a get request that redirects with HTTP 308 and disallowing redirects") {
+        val response = get("http://httpbin.org/redirect-to?status_code=308&url=http://httpbin.org/get", allowRedirects = false)
+        on("accessing the status code") {
+            val code = response.statusCode
+            it("should be 308") {
+                assertEquals(308, code)
             }
         }
     }


### PR DESCRIPTION
This commit provides support for following HTTP 307 and HTTP 308
redirects. Specifically, the `URL.openRedirectingConnection` function
(located in `GenericResponse.kt`) was updated to check for the HTTP
response code's presence in an array of redirect response codes
(301, 302, 303, 307, and 308). Previously, the function was only
checking for response codes in the range 301..303.

For information regarding these additional HTTP status codes, see:
  - [307 Temporary Redirect](https://tools.ietf.org/html/rfc7231#section-6.4.7)
  - [308 Permanent Redirect](https://tools.ietf.org/html/rfc7538#section-3)