### PR TITLE
Implement Bearer Token Authorization

### DIFF
--- a/src/main/kotlin/khttp/structures/authorization/BearerTokenAuthorization.kt
+++ b/src/main/kotlin/khttp/structures/authorization/BearerTokenAuthorization.kt
@@ -1,0 +1,15 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package khttp.structures.authorization
+
+import java.util.Base64
+
+data class BearerTokenAuthorization(val token: String) : Authorization {
+    override val header: Pair<String, String>
+        get() {
+            return "Authorization" to "Bearer $token"
+        }
+}

--- a/src/test/kotlin/khttp/structures/authorization/BearerTokenAuthorizationSpec.kt
+++ b/src/test/kotlin/khttp/structures/authorization/BearerTokenAuthorizationSpec.kt
@@ -11,7 +11,7 @@ import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.dsl.on
 import kotlin.test.assertEquals
 
-class BasicAuthorizationSpec : Spek({
+class BearerTokenAuthorizationSpec : Spek({
     given("a BearerTokenAuthorization object") {
         // Sample JWT token. See https://jwt.io/
         val token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"

--- a/src/test/kotlin/khttp/structures/authorization/BearerTokenAuthorizationSpec.kt
+++ b/src/test/kotlin/khttp/structures/authorization/BearerTokenAuthorizationSpec.kt
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package khttp.structures.authorization
+
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import kotlin.test.assertEquals
+
+class BasicAuthorizationSpec : Spek({
+    given("a BearerTokenAuthorization object") {
+        // Sample JWT token. See https://jwt.io/
+        val token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"
+        val auth = BearerTokenAuthorization(token)
+
+        on("checking the header") {
+            val (header, value) = auth.header
+            it("should have a first value of \"Authorization\"") {
+                assertEquals("Authorization", header)
+            }
+            it("should have a second value of the Base64 encoding") {
+                assertEquals("Bearer $token", value)
+            }
+        }
+    }
+})


### PR DESCRIPTION
This commit implements support for bearer token authorization. 

It's a pretty naive implementation, I don't think there's much complexity here.
Have added a simple unit test.

Hope this helps :)