### PR TITLE
Issue 49: 303 Redirects should use GET method

### DIFF
--- a/src/main/kotlin/khttp/responses/GenericResponse.kt
+++ b/src/main/kotlin/khttp/responses/GenericResponse.kt
@@ -129,7 +129,10 @@ class GenericResponse internal constructor(override val request: Request) : Resp
             val req = with(first.request) {
                 GenericResponse(
                     GenericRequest(
-                        method = this.method,
+                        method = when(connection.responseCode) {
+                            303 -> "GET"
+                            else -> this.method
+                        }                        
                         url = this@openRedirectingConnection.toURI().resolve(connection.getHeaderField("Location")).toASCIIString(),
                         headers = this.headers,
                         params = this.params,


### PR DESCRIPTION
Sending a POST-request to a site which is then redirecting back to itself results in reposting the request. This can result in an endless loop which eventually throws a StackOverflowException.

At least 303 Redirects should overwrite the request method to GET. Please read here:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Redirections#Temporary_redirections