### PR TITLE
JCenter over HTTPS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Stable releases are hosted on [JCenter](https://bintray.com/bintray/jcenter).
 ```xml
 <repository>
   <id>jcenter</id>
-  <url>http://jcenter.bintray.com/</url>
+  <url>https://jcenter.bintray.com/</url>
 </repository>
 <!-- ... -->
 <dependency>


### PR DESCRIPTION
[JCenter doesn’t support HTTP anymore](https://jfrog.com/jcenter-http/) and effectively breaks builds.